### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,19 +1,19 @@
 # Syntax Coloring Map 
 
 # Datatypes (KEYWORD1)
-ACpower    	KEYWORD1
+ACpower	KEYWORD1
 
 # Methods and Functions (KEYWORD2)
-init		KEYWORD2
-control		KEYWORD2
+init	KEYWORD2
+control	KEYWORD2
 setpower	KEYWORD2
-getpower    KEYWORD2
-Pnow		KEYWORD2
-Pset		KEYWORD2
-Pavg		KEYWORD2
-Inow		KEYWORD2
-Iset		KEYWORD2
-Uset		KEYWORD2
-Unow		KEYWORD2
+getpower	KEYWORD2
+Pnow	KEYWORD2
+Pset	KEYWORD2
+Pavg	KEYWORD2
+Inow	KEYWORD2
+Iset	KEYWORD2
+Uset	KEYWORD2
+Unow	KEYWORD2
 
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords